### PR TITLE
add generate.sh to create .goignore files

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,12 @@ It basically makes goimports fast again.
 go get github.com/maraino/goofimports
 ```
 
+### Generate
+
+A script `generate.sh` is included which can generate an optimal `.goignore`
+file (all directories that do not contain `.go` files in their subdirectories).
+To use it to generate your `.goignore` file:
+
+```sh
+sh "$GOPATH/src/github.com/maraino/goofimports/generate.sh" | tee "$GOPATH/.goignore"
+```

--- a/generate.sh
+++ b/generate.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+# generate.sh outputs a list of folders in $GOPATH that contain no `.go` files
+# in any subdirectory. It is an optimal list for goofimports.
+
+set -e
+
+search_dir() {
+    for d in "$1"/*
+    do
+        if [ -d "$d" ]
+        then
+            if find "$d" -name '*.go' | grep -q '.'
+            then
+                search_dir "$d"
+            else
+                echo "$d"
+            fi
+        fi
+    done
+}
+
+search_dir "$GOPATH/src"


### PR DESCRIPTION
A script `generate.sh` is included which can generate an optimal `.goignore`
file (all directories that do not contain `.go` files in their subdirectories).
